### PR TITLE
Recompile patterns when regex pool changes

### DIFF
--- a/R/filetree.R
+++ b/R/filetree.R
@@ -51,6 +51,7 @@ ft_add_regex <- function(ft, regexes) {
     stopifnot(length(rx) == 1, nzchar(rx))
     ft$regex_pool[[nm]] <- rx
   }
+  ft <- .ft_recompile_patterns(ft)
   ft
 }
 
@@ -86,6 +87,24 @@ ft_add_regex <- function(ft, regexes) {
   if (length(patterns) == 1 && is.null(names(patterns))) names(patterns) <- "default"
   stopifnot(!is.null(names(patterns)))
   patterns
+}
+
+.ft_recompile_patterns <- function(ft) {
+  for (layer in names(ft$dir_patterns)) {
+    spec <- ft$dir_patterns[[layer]]
+    if (is.null(spec) || length(spec) == 0) next
+    compiled <- lapply(spec$raw, .ft_compile_pattern, regex_pool = ft$regex_pool)
+    ft$dir_patterns[[layer]]$compiled <- compiled
+  }
+
+  for (at_layer in names(ft$file_patterns)) {
+    spec <- ft$file_patterns[[at_layer]]
+    if (is.null(spec) || length(spec) == 0) next
+    compiled <- lapply(spec$raw, .ft_compile_pattern, regex_pool = ft$regex_pool)
+    ft$file_patterns[[at_layer]]$compiled <- compiled
+  }
+
+  ft
 }
 
 # ---- directory patterns ----

--- a/tests/testthat/test-filetree.R
+++ b/tests/testthat/test-filetree.R
@@ -128,3 +128,40 @@ test_that("No problems in well-formed tree", {
     unique() |>
     expect_equal(0)
 })
+
+test_that("Pattern registration overwrites existing names and recompiles after regex updates", {
+  ft_overwrite <- ft_init(
+    root = root1,
+    layers = c("subject", "time", "data")
+  )
+
+  ft_overwrite <- ft_overwrite |>
+    ft_add_regex(c(
+      subject = "\\w{2}-\\d{2}",
+      time = "day\\d{2}"
+    )) |>
+    ft_add_dir_pattern(
+      layer = "subject",
+      patterns = c(main = "{subject}")
+    )
+
+  ft_overwrite <- ft_overwrite |>
+    ft_add_dir_pattern(
+      layer = "subject",
+      patterns = c(main = "{time}")
+    )
+
+  expect_equal(ft_overwrite$dir_patterns$subject$raw[["main"]], "{time}")
+  expect_equal(
+    ft_overwrite$dir_patterns$subject$compiled[["main"]],
+    "^(?<time>(?:day\\d{2}))$"
+  )
+
+  ft_overwrite <- ft_overwrite |>
+    ft_add_regex(c(time = "day\\d{3}"))
+
+  expect_equal(
+    ft_overwrite$dir_patterns$subject$compiled[["main"]],
+    "^(?<time>(?:day\\d{3}))$"
+  )
+})


### PR DESCRIPTION
### Motivation
- Ensure compiled patterns stored in `ft$dir_patterns` and `ft$file_patterns` reflect updates to `ft$regex_pool` so placeholder expansions stay correct.
- Avoid stale compiled regexes after calling `ft_add_regex()` which could lead to incorrect indexing or extraction.

### Description
- Update `ft_add_regex()` to invoke `.ft_recompile_patterns()` after updating `ft$regex_pool`.
- Add `.ft_recompile_patterns()` which walks `ft$dir_patterns` and `ft$file_patterns` and rebuilds each `compiled` entry from the stored `raw` patterns using the current `ft$regex_pool`.
- Existing pattern registration functions `ft_add_dir_pattern()` and `ft_add_file_pattern()` still compile on add and their `raw` patterns are used for future recompilation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724e83a930832584da038182571300)