### PR TITLE
Rewrite regex pool anchors for layer composition

### DIFF
--- a/R/filetree.R
+++ b/R/filetree.R
@@ -73,6 +73,9 @@ ft_add_regex <- function(ft, regexes) {
   compiled <- pattern
   for (nm in ph) {
     rx <- regex_pool[[nm]]
+    # Rewrite anchors so nested regexes still respect layer boundaries when
+    # embedded into a full path pattern.
+    rx <- .ft_rewrite_pool_anchors(rx)
     compiled <- stringr::str_replace_all(
       compiled,
       stringr::fixed(paste0("{", nm, "}")),
@@ -80,6 +83,16 @@ ft_add_regex <- function(ft, regexes) {
     )
   }
   paste0("^", compiled, "$")
+}
+
+.ft_rewrite_pool_anchors <- function(rx) {
+  if (stringr::str_starts(rx, stringr::fixed("^"))) {
+    rx <- stringr::str_replace(rx, "^\\^", "(?:(?<=/)|^)")
+  }
+  if (stringr::str_ends(rx, stringr::fixed("$"))) {
+    rx <- stringr::str_replace(rx, "\\$$", "(?:(?=/)|$)")
+  }
+  rx
 }
 
 .ft_normalize_patterns <- function(patterns) {

--- a/tests/testthat/test-filetree.R
+++ b/tests/testthat/test-filetree.R
@@ -165,3 +165,23 @@ test_that("Pattern registration overwrites existing names and recompiles after r
     "^(?<time>(?:day\\d{3}))$"
   )
 })
+
+test_that("Regex pool anchors match layer boundaries when composed", {
+  ft_anchor <- ft_init(
+    root = root1,
+    layers = c("subject", "data")
+  )
+
+  ft_anchor <- ft_anchor |>
+    ft_add_regex(c(subject = "^[A-Z]{3}\\d{2}$")) |>
+    ft_add_dir_pattern(
+      layer = "subject",
+      patterns = "{subject}"
+    )
+
+  compiled <- ft_anchor$dir_patterns$subject$compiled[["default"]]
+
+  expect_true(stringr::str_detect("ABC12", compiled))
+  expect_false(stringr::str_detect("AAA123", compiled))
+  expect_false(stringr::str_detect("AAAA12", compiled))
+})


### PR DESCRIPTION
### Motivation
- Regexes registered in the pool may include leading `^` and trailing `$` anchors which must be adapted when embedded into a full path regex so they continue to match per-layer boundaries rather than absolute string boundaries.

### Description
- Added helper ` .ft_rewrite_pool_anchors` which replaces a leading `^` with `(?:(?<=/)|^)` and a trailing `$` with `(?:(?=/)|$)` so pool regexes assert folder boundaries when composed.
- Integrated the helper into `.ft_compile_pattern` so each `{placeholder}` substitution uses the rewritten regex and preserved the outer `^...$` anchoring for per-layer matching.
- Added a short explanatory comment above the rewrite call in `R/filetree.R` and a unit test in `tests/testthat/test-filetree.R` that verifies an anchored pool entry like `^[A-Z]{3}\d{2}$` matches `ABC12` and rejects `AAA123` and `AAAA12`.

### Testing
- Added a new unit test in `tests/testthat/test-filetree.R` covering anchored regex pool entries, but no automated test suite was executed as part of this change.
- Existing tests in `tests/testthat/test-filetree.R` were left intact and will exercise compilation behavior when the test suite is run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69726b1f4d888325ad4e66e37626c641)